### PR TITLE
Add .gitignore file to filter common files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Ignore Python compiled files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Ignore virtual environments
+venv/
+env/
+.venv/
+
+# Ignore IDE specific files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Ignore log files and databases
+*.log
+*.sqlite3
+
+# Ignore build and distribution directories
+build/
+dist/
+*.egg-info/
+
+# Ignore system files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
This PR adds a `.gitignore` file to filter out common files like Python compiled files, virtual environments, IDE-specific files, logs, databases, and system files.